### PR TITLE
gh-polyglot 2.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 [![gh-polyglot](http://i.imgur.com/wQ2eGDb.png)](#)
 
-# gh-polyglot [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![Version](https://img.shields.io/npm/v/gh-polyglot.svg)](https://www.npmjs.com/package/gh-polyglot) [![Downloads](https://img.shields.io/npm/dt/gh-polyglot.svg)](https://www.npmjs.com/package/gh-polyglot) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
+# gh-polyglot
+
+ [![PayPal](https://img.shields.io/badge/%24-paypal-f39c12.svg)][paypal-donations] [![AMA](https://img.shields.io/badge/ask%20me-anything-1abc9c.svg)](https://github.com/IonicaBizau/ama) [![Version](https://img.shields.io/npm/v/gh-polyglot.svg)](https://www.npmjs.com/package/gh-polyglot) [![Downloads](https://img.shields.io/npm/dt/gh-polyglot.svg)](https://www.npmjs.com/package/gh-polyglot) [![Get help on Codementor](https://cdn.codementor.io/badges/get_help_github.svg)](https://www.codementor.io/johnnyb?utm_source=github&utm_medium=button&utm_term=johnnyb&utm_campaign=github)
 
 > Get language stats about GitHub users and repositories.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-polyglot",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "Get language stats about GitHub users and repositories.",
   "main": "lib/index.js",
   "directories": {
@@ -56,6 +56,7 @@
     "src/",
     "resources/",
     "menu/",
+    "scripts/",
     "cli.js",
     "index.js"
   ]


### PR DESCRIPTION
- Updated the README.md following the new template. :memo:
- Use [`babel-it`](https://github.com/IonicaBizau/babel-it) to babelify the code, so the module is now compatible with older versions of Node.js.
